### PR TITLE
Fixed game crashing when pygame doesn't exist.

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,9 @@ except ImportError:
         os.system("echo 🤡 imagine being on windows")
     else:
         os.system("python3 -m pip install pygame")
+    
+    # Reimport pygame after it's been installed
+    import pygame
 
 pygame.init()
 pygame.font.init()


### PR DESCRIPTION
When I tried running the game without PyGame installed, it automatically installs PyGame, but doesn't import it after PyGame is installed, which causes the call to `pygame.init()` to crash. I have fixed the issue in this pull request by importing PyGame after it's been installed.